### PR TITLE
Fixed a bug for parser vmware firmware all of which are EFI

### DIFF
--- a/prophet/parser/hosts/base.py
+++ b/prophet/parser/hosts/base.py
@@ -20,8 +20,8 @@ Inherit this class and implement each `parser` method in sub class.
 import logging
 
 # Boot type
-BIOS_BOOT = "bios"
-EFI_BOOT = "efi"
+BIOS_BOOT = "BIOS"
+EFI_BOOT = "EFI"
 
 # Default sign for uefi boot
 LINUX_EFI_MOUNT_POINT = "/boot/efi"


### PR DESCRIPTION
VMware parser _get_boot_type function return efi type, because base boot type define type str not upper